### PR TITLE
ensure we get the vboxmanage path

### DIFF
--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -3,6 +3,7 @@ async = require 'async'
 logsmith = require 'logsmith'
 child_process = require 'child_process'
 stream_buffers = require 'stream-buffers'
+vmp = require 'vboxmanage-path'
 
 ###
 	* Executes VBoxManage command. Commands are queued in order to prevent race conditions within VirtualBox.
@@ -15,7 +16,7 @@ exports.exec = do () ->
 	vboxmanage_path = switch
 		when process.platform.match /^win/ then path.join process.env.VBOX_INSTALL_PATH or '', 'VBoxManage.exe'
 		when process.platform.match /^dar/ then '/Applications/VirtualBox.app/Contents/MacOS/VBoxManage'
-		else 'VboxManage'
+		else vmp.sync()
 		
 	vboxmanage_queue = async.queue (task, callback) ->
 		task.run callback

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -13,10 +13,7 @@ vmp = require 'vboxmanage-path'
 	* @param {function(?err, code, output)} callback
 ###
 exports.exec = do () ->
-	vboxmanage_path = switch
-		when process.platform.match /^win/ then path.join process.env.VBOX_INSTALL_PATH or '', 'VBoxManage.exe'
-		when process.platform.match /^dar/ then '/Applications/VirtualBox.app/Contents/MacOS/VBoxManage'
-		else vmp.sync()
+	vboxmanage_path = vmp.sync()
 		
 	vboxmanage_queue = async.queue (task, callback) ->
 		task.run callback

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
 		"coffee-script": "1.6.3",
 		"async": "0.2.9",
 		"logsmith": "0.0.2",
-		"vboxmanage-path": "1.1.0"
+		"vboxmanage-path": "1.1.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"stream-buffers": "0.2.5",
 		"coffee-script": "1.6.3",
 		"async": "0.2.9",
-		"logsmith": "0.0.2"
+		"logsmith": "0.0.2",
+		"vboxmanage-path": "1.1.0"
 	}
 }


### PR DESCRIPTION
certain virtualbox installations only have VBoxManage (not VboxManage) - however others provide both (and maybe others supply only VboxManage (and not VBoxManage). `vboxmanage-path` deals with that. 

also - vmp.sync() would work on OS X too - but left the rest in tact for now (needs testing on windows) 
otherwise it could simply be

```
vboxmanage_path = vmp.sync()
```
